### PR TITLE
Remove hardware files release asset name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,4 +42,3 @@ jobs:
               uses: svenstaro/upload-release-action@v2
               with:
                   file: pcb-main-nautilus-atmega4809-${{ github.ref_name }}-hardware-files.zip
-                  asset_name: Hardware files (zip)


### PR DESCRIPTION
Resolves #34 (Remove hardware files release asset name).

Revert "Set hardware files release assert name (#33)"

This reverts commit d694f0532b9b04a9f78b10c7ab2c69e391a59690.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
